### PR TITLE
Add forecasting strategy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Market-Data-Forecasting
+
+This repository contains sample market data along with utilities for training forecasting models.
+
+## Usage
+
+A new script `forecast_strategy.py` demonstrates how to train a RandomForest model on the provided training data and evaluate it on the test set.
+
+Run the script with:
+
+```bash
+python forecast_strategy.py
+```
+
+It will output the first few predictions along with evaluation metrics (MSE, R2, Directional Accuracy).

--- a/forecast_strategy.py
+++ b/forecast_strategy.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from metrics import measure_performance
+
+
+def train_and_forecast(x_train_path="data/x_train.csv",
+                       y_train_path="data/y_train.csv",
+                       x_test_path="data/x_test.csv",
+                       y_test_path="data/y_test.csv"):
+    """Train RandomForest models and forecast test set."""
+    # Load datasets
+    x_train = pd.read_csv(x_train_path, index_col="timestamp")
+    y_train = pd.read_csv(y_train_path, index_col="timestamp")
+    x_test = pd.read_csv(x_test_path, index_col="timestamp")
+    y_test = pd.read_csv(y_test_path, index_col="timestamp")
+
+    # Prepare container for predictions
+    preds = pd.DataFrame(index=y_test.index, columns=y_test.columns)
+
+    # Fit a model per target column
+    for target in y_train.columns:
+        model = RandomForestRegressor(n_estimators=200, random_state=42)
+        model.fit(x_train, y_train[target])
+        preds[target] = model.predict(x_test)
+
+    # Evaluate
+    metrics = measure_performance(y_test.values, preds.values)
+    return preds, metrics
+
+
+if __name__ == "__main__":
+    predictions, evaluation = train_and_forecast()
+    print("Predictions:\n", predictions.head())
+    print("\nEvaluation metrics:\n", evaluation)


### PR DESCRIPTION
## Summary
- add `forecast_strategy.py` to train and predict with RandomForest
- update README with usage instructions

## Testing
- `python -m py_compile forecast_strategy.py`
- `python forecast_strategy.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687368b150c4832ea5a5d134ff855af1